### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/BSON/ObjectId.pm
+++ b/lib/BSON/ObjectId.pm
@@ -1,4 +1,4 @@
-class BSON::ObjectId;
+unit class BSON::ObjectId;
 
 # Represents ObjectId BSON type described in
 # http://dochub.mongodb.org/core/objectids


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.