### PR TITLE
Rename BSON::EDC-Tools to BSON::EDCTools to work round panda

### DIFF
--- a/META.info
+++ b/META.info
@@ -6,11 +6,12 @@
   "description": "BSON encoding/decoding, used in MongoDB drivers",
   "name": "BSON",
   "provides": {
-    "BSON::EDC-Tools":      "lib/BSON/EDC-Tools.pm6",
-    "BSON::Exception":      "lib/BSON/Exception.pm6",
-    "BSON::Javascript":     "lib/BSON/Javascript.pm",
-    "BSON::ObjectId":       "lib/BSON/ObjectId.pm",
-    "BSON::Regex":          "lib/BSON/Regex.pm"
+    "BSON::EDCTools":      "lib/BSON/EDCTools.pm6",
+	 "BSON::Binary":        "lib/BSON/Binary.pm",
+    "BSON::Exception":     "lib/BSON/Exception.pm6",
+    "BSON::Javascript":    "lib/BSON/Javascript.pm",
+    "BSON::ObjectId":      "lib/BSON/ObjectId.pm",
+    "BSON::Regex":         "lib/BSON/Regex.pm"
   },
   "source-url": "git://github.com/MARTIMM/BSON.git",
   "version": "0.9.7"

--- a/lib/BSON.pm
+++ b/lib/BSON.pm
@@ -1,9 +1,9 @@
 use v6;
+use BSON::EDCTools;
 use BSON::ObjectId;
 use BSON::Regex;
 use BSON::Javascript;
 use BSON::Binary;
-use BSON::EDC-Tools;
 use BSON::Exception;
 
 package BSON {

--- a/lib/BSON/Binary.pm
+++ b/lib/BSON/Binary.pm
@@ -1,5 +1,6 @@
 use v6;
-use BSON::EDC-Tools;
+
+use BSON::EDCTools;
 
 package BSON {
 

--- a/lib/BSON/EDCTools.pm6
+++ b/lib/BSON/EDCTools.pm6
@@ -4,7 +4,7 @@ use BSON::Exception;
 # Basic BSON encoding and decoding tools. These exported subs process
 # strings and integers.
 
-package BSON {
+module BSON::EDCTools {
 
   #-----------------------------------------------------------------------------
   # Encoding tools

--- a/t/102-int.t
+++ b/t/102-int.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use BSON::EDC-Tools;
+use BSON::EDCTools;
 
 #-------------------------------------------------------------------------------
 my $index;

--- a/t/103-string.t
+++ b/t/103-string.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-use BSON::EDC-Tools;
+use BSON::EDCTools;
 
 #-------------------------------------------------------------------------------
 my $index;


### PR DESCRIPTION
Hi,
I think probably the best solution is to fix the Panda::Builder so that it won't ignore module names with a '-' in, but this should get you started again.