### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -11,7 +11,7 @@
     "UUID"
   ],
   "description": "BSON encoding/decoding, used in MongoDB drivers",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "BSON",
   "provides": {
     "BSON":                     "lib/BSON.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license