### PR TITLE
This change fixes BSON choking when it encounters Rat numbers (usually from serialization)

### DIFF
--- a/lib/BSON/Document.pm6
+++ b/lib/BSON/Document.pm6
@@ -673,6 +673,14 @@ class Document does Associative {
 
     given $p.value {
 
+	  when Rat {
+		  # Only handle Rat if it can be converted without precision loss
+		  if .Num.Rat(0) == $_ {
+			  $_ .= Num;
+		  }
+		  proceed;
+	  }
+
       when Num {
         # Double precision
         # "\x01" e_name Num

--- a/lib/BSON/Document.pm6
+++ b/lib/BSON/Document.pm6
@@ -35,6 +35,7 @@ class Document does Associative {
   #
   my Bool $autovivify = False;
   my Bool $accept-hash = False;
+  my Bool $accept-rat = False;
 
   #-----------------------------------------------------------------------------
   # Make new document and initialize with a list of pairs
@@ -235,6 +236,11 @@ class Document does Associative {
   #-----------------------------------------------------------------------------
   submethod accept-hash ( Bool $acch = True ) {
     $accept-hash = $acch;
+  }
+
+  #-----------------------------------------------------------------------------
+  submethod accept-rat ( Bool $accr = True ) {
+    $accept-rat = $accr;
   }
 
   #-----------------------------------------------------------------------------
@@ -675,7 +681,7 @@ class Document does Associative {
 
 	  when Rat {
 		  # Only handle Rat if it can be converted without precision loss
-		  if .Num.Rat(0) == $_ {
+		  if $accept-rat || .Num.Rat(0) == $_ {
 			  $_ .= Num;
 		  }
 		  proceed;

--- a/lib/BSON/Document.pod6
+++ b/lib/BSON/Document.pod6
@@ -222,6 +222,12 @@ say $d<q>.keys;
 
 =end code
 
+=head2 accept-rat
+
+  submethod accept-rat ( Bool $accr = True )
+
+When true, rational numbers will be converted to double, regardless of precision loss. This is useful for dealing with messy input, since rational numbers cannot be encoded at this time. By default it is set to C<False>. Rational numbers that will not lose precision will be converted regardless of this setting.
+
 =head2 find-key
 
   multi method find-key ( Int:D $idx --> Str )


### PR DESCRIPTION
Floating point numbers in JSON or from other serialized data sources will normally be parsed as `Rat`. Since BSON can't yet handle `Rat`, the first commit converts to `Num` if there's no precision loss.

Secondly, I added an `accept-rat` option to convert all `Rat` to `Num` without checking whether there is precision loss. This is useful as a temporary measure until we can encode higher precision numbers in MongoDB.