### PR TITLE
Fix handling of dates, as set by `$currentDate`

### DIFF
--- a/lib/BSON/Document.pm6
+++ b/lib/BSON/Document.pm6
@@ -761,7 +761,7 @@ class Document does Associative {
         #
         $b = [~] Buf.new(BSON::C-DATETIME),
                  encode-e-name($p.key),
-                 encode-int64(.posix);
+                 encode-int64(((.posix+.second-.whole-second)*1000).Int);
       }
 
       when not .defined {
@@ -1079,8 +1079,8 @@ class Document does Associative {
 
         %!promises{$key} = Promise.start( {
             @!values[$idx] = DateTime.new(
-              decode-int64( $!encoded-document, $i),
-              :timezone($*TZ)
+              decode-int64( $!encoded-document, $i) / 1000,
+              :timezone(0)
             );
 
             $!encoded-document.subbuf(

--- a/t/320-document.t
+++ b/t/320-document.t
@@ -225,8 +225,8 @@ subtest {
     # 15
     BSON::C-DATETIME,                           # 0x09
       0x64, 0x74, 0x69, 0x6d, 0x65, 0x00,       # 'dtime'
-#      local-encode-int64($datetime.posix).List, # time
-      encode-int64($datetime.posix).List,       # time
+#      local-encode-int64((($datetime.posix+$datetime.second-$datetime.whole-second)*1000).Int).List,       # time
+      encode-int64((($datetime.posix+$datetime.second-$datetime.whole-second)*1000).Int).List,       # time
 
     # 6
     BSON::C-NULL,                               # 0x0A
@@ -281,7 +281,7 @@ subtest {
   is $d<oid>.oid.elems, 12, 'Length of object id ok';
   is $d<oid>.pid, $*PID, "Pid = $*PID";
 
-  is $d<dtime>.Str, $datetime.Str, 'Date and time ok';
+  is $d<dtime>.utc, $datetime.utc, 'Date and time ok';
 
   nok $d<null>.defined, 'Null not defined';
 


### PR DESCRIPTION
The raw value from the database seems to be milliseconds after the epoch. `DateTime.new()` wants seconds. And there should be no timezone offset—the date is stored in UTC. This fixes issue #25.

I'm not sure if #19 is a duplicate, but a comment indicated that that timestamp was stored as two ints, and that's not the case with the `$currentDate` timestamp.