### PR TITLE
Allow Documents to be destructured, like: sub foo(% (:_id($id))) {...}

### DIFF
--- a/lib/BSON/Document.pm6
+++ b/lib/BSON/Document.pm6
@@ -281,6 +281,12 @@ class Document does Associative {
     $value;
   }
 
+  # Enable BSON::Document to be destructured.
+  method Capture ( BSON::Document:D: --> Capture ) {
+
+    return (self.keys Z=> self.values).Capture;
+  }
+
   #-----------------------------------------------------------------------------
   method EXISTS-KEY ( Str $key --> Bool ) {
     self.find-key($key).defined;


### PR DESCRIPTION
This change allows BSON::Document to be destructured, just as hashes are.

See the docs here: https://docs.perl6.org/type/Signature#Destructuring_Parameters

This implements issue #27.