### PR TITLE
Implement slice assignment

### DIFF
--- a/lib/BSON/Document.pm6
+++ b/lib/BSON/Document.pm6
@@ -274,17 +274,20 @@ class Document does Associative {
     my $value;
     my Int $idx = self.find-key($key);
     if $idx.defined {
-      $value = @!values[$idx];
+      return-rw @!values[$idx];
     }
 
     # No key found so its undefined, check if we must make a new entry
     elsif $autovivify {
       $value = BSON::Document.new;
       self{$key} = $value;
+      return-rw self{$key};
 #say "At-key($?LINE): $key => ", $value.WHAT;
     }
 
-    $value;
+    else {
+      return Any;
+    }
   }
 
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit modifies `AT-KEY` so slice assignment works for Documents. For example:

    $doc<name1 name2> = @name;

Or more commonly:

    $doc{@keys} = %input{@keys};

Note that you can't currently parallel-assign to nonexistent keys unless $.autovivify is set. It would be nice to make this work, but for that you would need to be able to create a key without assigning anything, and that doesn't seem possible based on how keys and values are stored.