### PR TITLE
Large PID doesn't round trip, but we shouldn't care

### DIFF
--- a/t/110-objectid.t
+++ b/t/110-objectid.t
@@ -50,7 +50,6 @@ subtest {
 
   is $o.oid.elems, 12, 'Length oid ok';
   ok $time <= $o.time <= $time + 1, 'Time between this and the next second';
-  is $o.pid, $*PID, "Process is $*PID";
 
 }, 'Object id encoding/decoding';
 

--- a/t/320-document.t
+++ b/t/320-document.t
@@ -279,7 +279,6 @@ subtest {
   is $d<array>[[2]], 345, 'A[[2]] = 345';
 
   is $d<oid>.oid.elems, 12, 'Length of object id ok';
-  is $d<oid>.pid, $*PID, "Pid = $*PID";
 
   is $d<dtime>.utc, $datetime.utc, 'Date and time ok';
 


### PR DESCRIPTION
See https://github.com/MARTIMM/BSON/issues/32 and https://github.com/rakudo/rakudo/issues/3850#issuecomment-676619811 for more details, but in essence:

This library has split the ObjectID 5-byte "random value" field as described
in https://docs.mongodb.com/manual/reference/method/ObjectId/ into two
subfields: a 3-byte machine name hash, and a 2-byte process ID.  Unfortunately
since most modern Linux/*nix systems use larger process IDs, this simply takes
the first two bytes of the actual PID.  That would not in itself be a problem,
except that the tests check that the actual PID can be extracted back out of
the ObjectID; these tests fail if the real PID happens to be larger than 65535.

Since the spec doesn't actually *require* any structure to the "random value"
field, just stop testing for this round tripping.